### PR TITLE
Developer Toolsへのプロビジョニング問題の修正

### DIFF
--- a/resources/chapter-3/resource-database.xml
+++ b/resources/chapter-3/resource-database.xml
@@ -105,6 +105,15 @@
                     </source>
                 </outbound>
             </attribute>
+            <attribute>
+                <ref>ri:accesslevel</ref>
+                <!--
+                    Development Application RoleとDevelopment Manager Roleの両方を
+                    保持している場合に、strongマッピングとしたDevelopment Manager Role
+                    を優先させるために設定
+                -->
+                <exclusiveStrong>true</exclusiveStrong>
+            </attribute>
             <activation>
                 <administrativeStatus>
                     <outbound />

--- a/resources/chapter-4/resource-csv-hr.xml
+++ b/resources/chapter-4/resource-csv-hr.xml
@@ -127,6 +127,18 @@
                     </expression>
                     <target>
                         <path>$focus/assignment</path>
+                        <!--
+                            役職変更時にDevelopment Manager Roleを解除する
+                        -->
+                        <set>
+                            <condition>
+                                <script>
+                                    <code>
+                                        midpoint.resolveReferenceIfExists(input?.targetRef)?.name?.orig == 'Development Manager Role'
+                                    </code>
+                                </script>
+                            </condition>
+                        </set>
                     </target>
                     <condition>
                         <script>

--- a/resources/chapter-7/resource-csv-hr.xml
+++ b/resources/chapter-7/resource-csv-hr.xml
@@ -135,6 +135,18 @@
                     </expression>
                     <target>
                         <path>$focus/assignment</path>
+                        <!--
+                            役職変更時にDevelopment Manager Roleを解除する
+                        -->
+                        <set>
+                            <condition>
+                                <script>
+                                    <code>
+                                        midpoint.resolveReferenceIfExists(input?.targetRef)?.name?.orig == 'Development Manager Role'
+                                    </code>
+                                </script>
+                            </condition>
+                        </set>
                     </target>
                     <condition>
                         <script>


### PR DESCRIPTION
- 役職が係長のユーザを再計算するとaccesslevelがコンフリクトする (係長は課に所属しており、課に所属すると自動的に`Development Application Role`を持つため、係長に適用される`Development Manager Role`とコンフリクトする)
- 役職が係長/部長から一般社員に変更となった場合に`Development Manager Roleが解除されない